### PR TITLE
Create Non-overlapping Intervals

### DIFF
--- a/C++/Non-overlapping Intervals
+++ b/C++/Non-overlapping Intervals
@@ -1,0 +1,22 @@
+class Solution {
+public:
+    static bool cmp(vector<int>&a , vector<int>&b){
+        return a[1]<b[1];
+    }
+
+    int eraseOverlapIntervals(vector<vector<int>>& intervals) {
+        int n = intervals.size();
+        sort(intervals.begin(),intervals.end(),cmp);
+        
+        int prev = 0;
+        int res = 1;
+        for(int curr = 1; curr<n ; curr++){
+            if(intervals[curr][0] >= intervals[prev][1]){
+                res++;
+                prev = curr;
+            }
+        }
+
+        return n-res;
+    }
+};


### PR DESCRIPTION
Given an array of intervals intervals where intervals[i] = [starti, endi], return the minimum number of intervals you need to remove to make the rest of the intervals non-overlapping.